### PR TITLE
Run CppCheck as part of CI

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,28 @@
+name: CppCheck
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - .github/workflows/cppcheck.yml
+    - '**.[ch]'
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Install cppcheck
+      run: sudo apt-get install -qq cppcheck
+    - name: Run cppcheck
+      run: >
+        cppcheck
+        --quiet
+        --force
+        --enable=all
+        --error-exitcode=1
+        .


### PR DESCRIPTION
The great part about CppCheck is that it doesn't require a build, so we can just scan our BSD source code on Linux.